### PR TITLE
Add Custom 404 Page to NextJs & show on 404s within Cloudfront

### DIFF
--- a/cdk/stack.ts
+++ b/cdk/stack.ts
@@ -55,7 +55,12 @@ export class Stack extends cdk.Stack {
                         isDefaultBehavior: true
                     }]
                 }
-            ]
+            ],
+            errorConfigurations: [{
+                errorCode: 404,
+                responseCode: 404,
+                responsePagePath: '/404.html'
+            }]
         });
 
         // A Record 

--- a/pages/404.js
+++ b/pages/404.js
@@ -1,0 +1,17 @@
+import Head from 'next/head';
+import Layout from '../components/layout'
+
+export default function InvalidPage() {
+
+    return (
+        <Layout>
+            <Head>
+                <title>Page Not Found</title>
+            </Head>
+            <section>
+                <p>Invalid Page</p>
+                <p>Page does not exist</p>
+            </section>
+        </Layout>
+    )
+};


### PR DESCRIPTION
As the title suggestions

- Add a custom NextJs 404 page
- Routes 404 requests to the custom 404 html file